### PR TITLE
Add GET_FW_VERSION cmd for app firmware version

### DIFF
--- a/main/tanmatsu/lora/lora_protocol.h
+++ b/main/tanmatsu/lora/lora_protocol.h
@@ -3,17 +3,19 @@
 #include <stdint.h>
 
 #define LORA_PROTOCOL_VERSION_STRING_LENGTH 16
+#define LORA_PROTOCOL_FW_VERSION_STRING_LENGTH 32
 
 typedef enum {
-    LORA_PROTOCOL_TYPE_ACK        = 0x00,
-    LORA_PROTOCOL_TYPE_NACK       = 0x01,
-    LORA_PROTOCOL_TYPE_GET_MODE   = 0x02,
-    LORA_PROTOCOL_TYPE_SET_MODE   = 0x03,
-    LORA_PROTOCOL_TYPE_GET_CONFIG = 0x04,
-    LORA_PROTOCOL_TYPE_SET_CONFIG = 0x05,
-    LORA_PROTOCOL_TYPE_GET_STATUS = 0x06,
-    LORA_PROTOCOL_TYPE_PACKET_RX  = 0x07,
-    LORA_PROTOCOL_TYPE_PACKET_TX  = 0x08,
+    LORA_PROTOCOL_TYPE_ACK            = 0x00,
+    LORA_PROTOCOL_TYPE_NACK           = 0x01,
+    LORA_PROTOCOL_TYPE_GET_MODE       = 0x02,
+    LORA_PROTOCOL_TYPE_SET_MODE       = 0x03,
+    LORA_PROTOCOL_TYPE_GET_CONFIG     = 0x04,
+    LORA_PROTOCOL_TYPE_SET_CONFIG     = 0x05,
+    LORA_PROTOCOL_TYPE_GET_STATUS     = 0x06,
+    LORA_PROTOCOL_TYPE_PACKET_RX      = 0x07,
+    LORA_PROTOCOL_TYPE_PACKET_TX      = 0x08,
+    LORA_PROTOCOL_TYPE_GET_FW_VERSION = 0x09,  // app firmware version (esp_app_desc->version)
 } lora_protocol_packet_type_t;
 
 typedef enum {
@@ -58,6 +60,11 @@ typedef struct {
     uint8_t length;
     uint8_t data[];
 } __attribute__((packed)) lora_protocol_lora_packet_t;
+
+// Response payload for GET_FW_VERSION (app firmware version string from esp_app_desc).
+typedef struct {
+    char version[LORA_PROTOCOL_FW_VERSION_STRING_LENGTH];  // NUL-terminated; truncated to fit
+} __attribute__((packed)) lora_protocol_fw_version_params_t;
 
 typedef struct {
     uint32_t sequence_number;

--- a/main/tanmatsu/lora/lora_protocol_server.c
+++ b/main/tanmatsu/lora/lora_protocol_server.c
@@ -4,6 +4,8 @@
 #include "lora_protocol_server.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
+#include "esp_app_desc.h"
 #include "esp_err.h"
 #include "esp_hosted_peer_data.h"
 #include "esp_log.h"
@@ -350,6 +352,27 @@ static void send_status(uint32_t sequence_number) {
     generate_custom_event(TANMATSU_EVENT_LORA, reply_buffer, status_length);
 }
 
+// Respond with the app firmware version string from esp_app_get_description().
+static void send_fw_version(uint32_t sequence_number) {
+    lora_protocol_header_t* hdr = (lora_protocol_header_t*)reply_buffer;
+    hdr->sequence_number        = sequence_number;
+    hdr->type                   = LORA_PROTOCOL_TYPE_GET_FW_VERSION;
+    lora_protocol_fw_version_params_t* params =
+        (lora_protocol_fw_version_params_t*)(reply_buffer + sizeof(lora_protocol_header_t));
+
+    memset(params->version, 0, sizeof(params->version));
+    const esp_app_desc_t* desc = esp_app_get_description();
+    if (desc && desc->version[0]) {
+        strncpy(params->version, desc->version, sizeof(params->version) - 1);
+    } else {
+        strncpy(params->version, "UNKNOWN", sizeof(params->version) - 1);
+    }
+    params->version[sizeof(params->version) - 1] = '\0';
+
+    generate_custom_event(TANMATSU_EVENT_LORA, reply_buffer,
+                          sizeof(lora_protocol_header_t) + sizeof(lora_protocol_fw_version_params_t));
+}
+
 static uint32_t lora_calculate_tx_time_ms(const lora_protocol_config_params_t* config, uint8_t payload_length) {
     if (config == NULL || config->bandwidth == 0 || config->spreading_factor < 5 || config->spreading_factor > 12) {
         return 10000;  // Invalid configuration will yield a 10 second timeout
@@ -538,6 +561,9 @@ void lora_protocol_handle_packet(uint8_t* request_buffer, size_t request_length)
             } else {
                 send_nack(packet->sequence_number);
             }
+            break;
+        case LORA_PROTOCOL_TYPE_GET_FW_VERSION:
+            send_fw_version(packet->sequence_number);
             break;
         default:
             ESP_LOGW(TAG, "Unknown command: %d\r\n", packet->type);


### PR DESCRIPTION
## Summary

Adds a new protocol cmd (`LORA_PROTOCOL_TYPE_GET_FW_VERSION = 0x09`) that returns `esp_app_get_description()->version` over the existing LoRa-over-SDIO transport, so the host (P4) can display the actual radio firmware version (e.g. `v3.0.0-N-gSHA`) instead of hard-coding a label in the host app.

Pairs with [`CJvanSoest/esp32-component-tanmatsu-lora#feature/fw-version-expose`](https://github.com/CJvanSoest/esp32-component-tanmatsu-lora/tree/feature/fw-version-expose) which adds the matching `lora_get_fw_version()` client API.

## Changes

- `lora_protocol.h`: new enum value `LORA_PROTOCOL_TYPE_GET_FW_VERSION = 0x09`, new `lora_protocol_fw_version_params_t` struct, `LORA_PROTOCOL_FW_VERSION_STRING_LENGTH = 32`.
- `lora_protocol_server.c`: new `send_fw_version()` handler invoked from the protocol dispatch; reads `esp_app_get_description()->version` (or `"UNKNOWN"` if unavailable).

## Compatibility

- Old host apps without the new client API are unaffected — cmd is purely additive.
- Old C6 firmware without the cmd replies with NACK; the matching client API in the companion component PR maps that to `ESP_ERR_NOT_SUPPORTED` so host apps can fall back to a static label.

## Test plan

- [x] Builds clean for `esp32c6` target.
- [x] Smoketest on Tanmatsu rev 5: P4 boots, queries the C6, displays the resolved version string in the host app's Settings screen.